### PR TITLE
Redirect unauthenticated Qubito users to Pixel Grimoire

### DIFF
--- a/src/contexts/EntitlementsContext.tsx
+++ b/src/contexts/EntitlementsContext.tsx
@@ -159,8 +159,6 @@ export function EntitlementsProvider({ children }: { children: React.ReactNode }
           try {
             window.localStorage.setItem("qubito_tenant", tenantHint);
           } catch {}
-          setError(msg);
-          return;
         }
         const base = process.env.NEXT_PUBLIC_ENTITLEMENTS_BASE_URL || process.env.ENTITLEMENTS_BASE_URL || "";
         // On unauthenticated, send users to landing sign-in with a redirect


### PR DESCRIPTION
## Summary
- redirect users to Pixel Grimoire when entitlements token returns unauthenticated
- keep persisting tenant hint before redirect

## Why
Qubito was leaving users on the login error screen instead of sending them to Pixel Grimoire sign-in when the landing session was missing.
